### PR TITLE
Fix voor verplicht zijn van 'vanaf' parameter

### DIFF
--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -153,7 +153,7 @@ paths:
       parameters:
         - in: query
           name: vanaf
-          required: false
+          required: true
           explode: false
           description: Alleen personen waarbij gegevens zijn gewijzigd op of na deze datum worden geleverd.
           schema:


### PR DESCRIPTION
het is al zo geïmplementeerd maar de specs hadden dit verkeerd staan